### PR TITLE
Remove redundant nil checks

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -232,10 +232,8 @@ func (cli *Client) addHeaders(req *http.Request, headers headers) *http.Request 
 		req.Header.Set(k, v)
 	}
 
-	if headers != nil {
-		for k, v := range headers {
-			req.Header[k] = v
-		}
+	for k, v := range headers {
+		req.Header[k] = v
 	}
 	return req
 }

--- a/daemon/links/links.go
+++ b/daemon/links/links.go
@@ -92,18 +92,16 @@ func (l *Link) ToEnv() []string {
 	// Load the linked container's name into the environment
 	env = append(env, fmt.Sprintf("%s_NAME=%s", alias, l.Name))
 
-	if l.ChildEnvironment != nil {
-		for _, v := range l.ChildEnvironment {
-			parts := strings.SplitN(v, "=", 2)
-			if len(parts) < 2 {
-				continue
-			}
-			// Ignore a few variables that are added during docker build (and not really relevant to linked containers)
-			if parts[0] == "HOME" || parts[0] == "PATH" {
-				continue
-			}
-			env = append(env, fmt.Sprintf("%s_ENV_%s=%s", alias, parts[0], parts[1]))
+	for _, v := range l.ChildEnvironment {
+		parts := strings.SplitN(v, "=", 2)
+		if len(parts) < 2 {
+			continue
 		}
+		// Ignore a few variables that are added during docker build (and not really relevant to linked containers)
+		if parts[0] == "HOME" || parts[0] == "PATH" {
+			continue
+		}
+		env = append(env, fmt.Sprintf("%s_ENV_%s=%s", alias, parts[0], parts[1]))
 	}
 	return env
 }


### PR DESCRIPTION
These nil checks before the range loop are redundant (see https://staticcheck.io/docs/gosimple#S1031)